### PR TITLE
fix(WebsocketStream) Fixes an issue that left a WebSocket stream broken after dispose

### DIFF
--- a/Frontend/Tunnel/WebSocketStream.cs
+++ b/Frontend/Tunnel/WebSocketStream.cs
@@ -6,6 +6,7 @@ internal class WebSocketStream : Stream, IValueTaskSource<object?>, ICloseable
 {
     private readonly WebSocket _ws;
     private ManualResetValueTaskSourceCore<object?> _tcs = new() { RunContinuationsAsynchronously = true };
+    private readonly CancellationTokenSource _disposeTokenSource = new();
     private readonly object _sync = new();
 
     public WebSocketStream(WebSocket ws)
@@ -62,7 +63,9 @@ internal class WebSocketStream : Stream, IValueTaskSource<object?>, ICloseable
 
     public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
     {
-        var result = await _ws.ReceiveAsync(buffer, cancellationToken);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _disposeTokenSource.Token);
+        
+        var result = await _ws.ReceiveAsync(buffer, linkedCts.Token);
 
         if (result.MessageType == WebSocketMessageType.Close)
         {
@@ -106,6 +109,9 @@ internal class WebSocketStream : Stream, IValueTaskSource<object?>, ICloseable
             {
                 return;
             }
+            
+            // Cancel the token to signal the read loop to stop
+            _disposeTokenSource.Cancel();
 
             // This might seem evil but we're using dispose to know if the stream
             // has been given discarded by http client. We trigger the continuation and take back ownership

--- a/Frontend/Tunnel/WebSocketStream.cs
+++ b/Frontend/Tunnel/WebSocketStream.cs
@@ -6,7 +6,7 @@ internal class WebSocketStream : Stream, IValueTaskSource<object?>, ICloseable
 {
     private readonly WebSocket _ws;
     private ManualResetValueTaskSourceCore<object?> _tcs = new() { RunContinuationsAsynchronously = true };
-    private readonly CancellationTokenSource _disposeTokenSource = new();
+    private  CancellationTokenSource _disposeTokenSource = new();
     private readonly object _sync = new();
 
     public WebSocketStream(WebSocket ws)
@@ -112,6 +112,10 @@ internal class WebSocketStream : Stream, IValueTaskSource<object?>, ICloseable
             
             // Cancel the token to signal the read loop to stop
             _disposeTokenSource.Cancel();
+            _disposeTokenSource.Dispose();
+
+            // Create a fresh token source 
+            _disposeTokenSource = new();
 
             // This might seem evil but we're using dispose to know if the stream
             // has been given discarded by http client. We trigger the continuation and take back ownership


### PR DESCRIPTION
This resolves an issue that left the WebSocket stream broken after it has been disposed and rerequested by the ConnectCallback. The issue seems to be caused by long waiting reads of 0 bytes that don't get canceled by the framework code calling the read method. So as a quick fix, this creates a linked cancelation token that gets canceled if dispose is called.